### PR TITLE
Fix links in Custom Orchestrator guide

### DIFF
--- a/docs/guide/custom_orchestrator.md
+++ b/docs/guide/custom_orchestrator.md
@@ -14,9 +14,9 @@ TFX orchestrators take the logical pipeline object, which contains pipeline
 args, components, and DAG, and are responsible for scheduling components of the
 TFX pipeline based on the dependencies defined by the DAG.
 
-For example, let's look at how to create a custom orchestrator with 
-[ComponentLauncher](https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/component_launcher.py).
-ComponentLauncher already handles driver, executor, and publisher of a single
+For example, let's look at how to create a custom orchestrator with
+[BaseComponentLauncher](https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/launcher/base_component_launcher.py).
+BaseComponentLauncher already handles driver, executor, and publisher of a single
 component. The new orchestrator just needs to schedule ComponentLaunchers based
 on the DAG. A simple orchestrator is provided as the [LocalDagRunner]
 (https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/local/local_dag_runner.py),

--- a/docs/guide/custom_orchestrator.md
+++ b/docs/guide/custom_orchestrator.md
@@ -8,7 +8,7 @@ orchestrators in addition to the default orchestrators that are supported by
 TFX, namely [Local](local_orchestrator.md), [Airflow](airflow.md) and
 [Kubeflow](kubeflow.md).
 
-All orchestrators must inherit from
+All orchestrators must inherit from 
 [TfxRunner](https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/tfx_runner.py).
 TFX orchestrators take the logical pipeline object, which contains pipeline
 args, components, and DAG, and are responsible for scheduling components of the

--- a/docs/guide/custom_orchestrator.md
+++ b/docs/guide/custom_orchestrator.md
@@ -8,10 +8,10 @@ orchestrators in addition to the default orchestrators that are supported by
 TFX, namely [Local](local_orchestrator.md), [Airflow](airflow.md) and
 [Kubeflow](kubeflow.md).
 
-All orchestrators must inherit from 
+All orchestrators must inherit from
 [TfxRunner](https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/tfx_runner.py).
 TFX orchestrators take the logical pipeline object, which contains pipeline
-args, components, and DAG, and are responsible for scheduling components of the
+args, components, and DAG, and are responsible for scheduling components of the 
 TFX pipeline based on the dependencies defined by the DAG.
 
 For example, let's look at how to create a custom orchestrator with

--- a/docs/guide/custom_orchestrator.md
+++ b/docs/guide/custom_orchestrator.md
@@ -5,7 +5,7 @@
 TFX is designed to be portable to multiple environments and orchestration
 frameworks. Developers can create custom orchestrators or add additional
 orchestrators in addition to the default orchestrators that are supported by
-TFX, namely [Airflow](airflow.md), [Beam](beam_orchestrator.md) and
+TFX, namely [Local](local_orchestrator.md), [Airflow](airflow.md) and
 [Kubeflow](kubeflow.md).
 
 All orchestrators must inherit from

--- a/docs/guide/custom_orchestrator.md
+++ b/docs/guide/custom_orchestrator.md
@@ -11,10 +11,10 @@ TFX, namely [Local](local_orchestrator.md), [Airflow](airflow.md) and
 All orchestrators must inherit from
 [TfxRunner](https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/tfx_runner.py).
 TFX orchestrators take the logical pipeline object, which contains pipeline
-args, components, and DAG, and are responsible for scheduling components of the 
+args, components, and DAG, and are responsible for scheduling components of the
 TFX pipeline based on the dependencies defined by the DAG.
 
-For example, let's look at how to create a custom orchestrator with
+For example, let's look at how to create a custom orchestrator with 
 [ComponentLauncher](https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/component_launcher.py).
 ComponentLauncher already handles driver, executor, and publisher of a single
 component. The new orchestrator just needs to schedule ComponentLaunchers based


### PR DESCRIPTION
Not sure the guide is still relevant but I found it online and some of the links are broken.